### PR TITLE
UI操作のPad対応・キャラ選択画面改良

### DIFF
--- a/Assets/TextMesh Pro/Fonts/LINESeedJP/LINESeedJP-Bold SDF.asset.meta
+++ b/Assets/TextMesh Pro/Fonts/LINESeedJP/LINESeedJP-Bold SDF.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c7e1bdf4d6a36b458ad17683dc3bd71
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TextMesh Pro/Fonts/LINESeedJP/LINESeedJP-Bold SDF.asset.meta
+++ b/Assets/TextMesh Pro/Fonts/LINESeedJP/LINESeedJP-Bold SDF.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 5c7e1bdf4d6a36b458ad17683dc3bd71
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 11400000
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/_Application/Lobby/Data/CharacterSelectionStore.asset
+++ b/Assets/_Application/Lobby/Data/CharacterSelectionStore.asset
@@ -12,4 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d0402f7281958c7479dee426818c8617, type: 3}
   m_Name: CharacterSelectionStore
   m_EditorClassIdentifier: Uraty.Feature.Akane_TestCharacter::Uraty.Application.Lobby.CharacterSelectionStore
-  _defaultCharacter: {fileID: 11400000, guid: bcbb5542a9cc73e48a4fd3760878d473, type: 2}
+  _defaultCharacterPrefab: {fileID: 7931562737157900142, guid: e4f55ec51b5d5d346a0a6a7fedc573aa, type: 3}
+  _selectedCharacterPrefab: {fileID: 0}

--- a/Assets/_Application/Lobby/Prefabs/ModeButtonView.prefab
+++ b/Assets/_Application/Lobby/Prefabs/ModeButtonView.prefab
@@ -103,9 +103,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1

--- a/Assets/_Application/Lobby/Scenes/LobbyCharacterSelectScene.unity
+++ b/Assets/_Application/Lobby/Scenes/LobbyCharacterSelectScene.unity
@@ -149,8 +149,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1750033331}
+  - {fileID: 387354208}
   - {fileID: 619568255}
   - {fileID: 446670390}
+  - {fileID: 1152635833}
   - {fileID: 1057750977}
   m_Father: {fileID: 1627674365}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -197,6 +200,143 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8983959}
   m_CullTransparentMesh: 1
+--- !u!1 &296848593
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 296848596}
+  - component: {fileID: 296848595}
+  - component: {fileID: 296848594}
+  m_Layer: 5
+  m_Name: CharacterNameText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &296848594
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 296848593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 1747fc09730a35a489ec5f2eb08bd36f, type: 2}
+  m_sharedMaterial: {fileID: 2013200219617406699, guid: 1747fc09730a35a489ec5f2eb08bd36f, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 48
+  m_fontSizeBase: 48
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: -20.868286, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &296848595
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 296848593}
+  m_CullTransparentMesh: 1
+--- !u!224 &296848596
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 296848593}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 387354208}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -660, y: 300}
+  m_SizeDelta: {x: 250, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &302853227
 GameObject:
   m_ObjectHideFlags: 0
@@ -222,12 +362,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 302853227}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0, y: -0, z: -0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -960, y: -540, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 619568255}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &302853229
 MonoBehaviour:
@@ -242,23 +382,107 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Uraty.Application.Lobby::Uraty.Application.Lobby.CharacterSelectSceneController
   _gameInput: {fileID: 0}
-  _characters:
-  - {fileID: 11400000, guid: 28c4f3209bd6daa47a46ac1de4c7a3bd, type: 2}
-  - {fileID: 11400000, guid: bcbb5542a9cc73e48a4fd3760878d473, type: 2}
-  - {fileID: 11400000, guid: b64a2d6f04743a346b5fe100c4894c90, type: 2}
-  - {fileID: 11400000, guid: 9ac2c549cf8c73e49bb6f7777645f55d, type: 2}
-  _previewSlots:
-  - {fileID: 472258924}
-  - {fileID: 505757213}
-  - {fileID: 1697654950}
-  - {fileID: 769504549}
-  _selectedCharacterNameText: {fileID: 0}
+  _characterSelectionStore: {fileID: 11400000, guid: 6e4d667cd6baba6438ef866126af715e, type: 2}
+  _characterPrefabs:
+  - {fileID: 7931562737157900142, guid: e4f55ec51b5d5d346a0a6a7fedc573aa, type: 3}
+  - {fileID: 414510161762077789, guid: e3ab0d20fafe40b4e956a3adf576b039, type: 3}
+  - {fileID: 9095663280809155271, guid: 76225e6227f412541bdd9faa383d1b72, type: 3}
+  - {fileID: 64248493349735629, guid: bc73278e7d937af409cf4ea00c555844, type: 3}
+  _carouselRoot: {fileID: 1856869783}
+  _selectCamera: {fileID: 0}
+  _slotSpacing: 2.5
+  _moveSpeed: 10
+  _rayDistance: 1000
+  _visibleSideCount: 2
+  _selectedScale: 2
+  _nearSideScale: 1
+  _farSideScale: 0.75
+  _characterNameText: {fileID: 296848594}
+  _characterDescriptionText: {fileID: 1345118777}
   _decideButton: {fileID: 1057750978}
   _closeButton: {fileID: 446670391}
-  _selectedScale: 2
-  _rayDistance: 1000
-  _selectCamera: {fileID: 0}
-  _characterSelectionStore: {fileID: 11400000, guid: 6e4d667cd6baba6438ef866126af715e, type: 2}
+  _dragThreshold: 10
+  _gamepadInputThreshold: 0.6
+  _gamepadRepeatSeconds: 0.25
+  _dragArea: {fileID: 619568254}
+  _firstSelectable: {fileID: 1152635830}
+--- !u!1 &387354207
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 387354208}
+  - component: {fileID: 387354210}
+  - component: {fileID: 387354209}
+  m_Layer: 5
+  m_Name: InfoPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &387354208
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 387354207}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 296848596}
+  - {fileID: 1345118779}
+  m_Father: {fileID: 8983960}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.33, y: 1}
+  m_AnchoredPosition: {x: 643, y: 0}
+  m_SizeDelta: {x: 1286, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &387354209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 387354207}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.1764706}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &387354210
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 387354207}
+  m_CullTransparentMesh: 1
 --- !u!1 &446670389
 GameObject:
   m_ObjectHideFlags: 0
@@ -293,9 +517,9 @@ RectTransform:
   - {fileID: 592892130}
   m_Father: {fileID: 8983960}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -944, y: 581}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 300, y: -100}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &446670391
@@ -311,18 +535,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 4
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
+    m_SelectOnDown: {fileID: 1152635830}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -591,7 +815,7 @@ GameObject:
   - component: {fileID: 619568257}
   - component: {fileID: 619568256}
   m_Layer: 5
-  m_Name: BackGround
+  m_Name: DragArea
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -608,13 +832,14 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 302853228}
   m_Father: {fileID: 8983960}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.33, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -317, y: 0}
+  m_SizeDelta: {x: 634, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &619568256
 MonoBehaviour:
@@ -630,7 +855,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
   m_Color: {r: 0.7686275, g: 0.7686275, b: 0.7686275, a: 0}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -654,6 +879,85 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 619568254}
   m_CullTransparentMesh: 1
+--- !u!1 &645097901
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 645097904}
+  - component: {fileID: 645097903}
+  - component: {fileID: 645097905}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &645097903
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 645097901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.EventSystems.EventSystem
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &645097904
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 645097901}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &645097905
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 645097901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.InputSystem::UnityEngine.InputSystem.UI.InputSystemUIInputModule
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
 --- !u!1 &769504548
 GameObject:
   m_ObjectHideFlags: 0
@@ -856,9 +1160,9 @@ RectTransform:
   - {fileID: 1053092644}
   m_Father: {fileID: 8983960}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -464}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 100}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1057750978
@@ -874,18 +1178,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 4
     m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
+    m_SelectOnUp: {fileID: 1152635830}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -943,6 +1247,264 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1057750976}
   m_CullTransparentMesh: 1
+--- !u!1 &1152635829
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1152635833}
+  - component: {fileID: 1152635832}
+  - component: {fileID: 1152635831}
+  - component: {fileID: 1152635830}
+  m_Layer: 5
+  m_Name: CharacterFocusButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1152635830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1152635829}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 4
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 446670391}
+    m_SelectOnDown: {fileID: 1057750978}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1152635831}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1152635831
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1152635829}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1152635832
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1152635829}
+  m_CullTransparentMesh: 1
+--- !u!224 &1152635833
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1152635829}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1617219582}
+  m_Father: {fileID: 8983960}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1345118776
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1345118779}
+  - component: {fileID: 1345118778}
+  - component: {fileID: 1345118777}
+  m_Layer: 5
+  m_Name: CharacterDescriptionText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1345118777
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1345118776}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 1747fc09730a35a489ec5f2eb08bd36f, type: 2}
+  m_sharedMaterial: {fileID: 2013200219617406699, guid: 1747fc09730a35a489ec5f2eb08bd36f, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1345118778
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1345118776}
+  m_CullTransparentMesh: 1
+--- !u!224 &1345118779
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1345118776}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 387354208}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -525, y: -100}
+  m_SizeDelta: {x: 500, y: 750}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1386235777
 GameObject:
   m_ObjectHideFlags: 0
@@ -1040,6 +1602,143 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1617219581
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1617219582}
+  - component: {fileID: 1617219584}
+  - component: {fileID: 1617219583}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1617219582
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617219581}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1152635833}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1617219583
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617219581}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1617219584
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617219581}
+  m_CullTransparentMesh: 1
 --- !u!1 &1627674361
 GameObject:
   m_ObjectHideFlags: 0
@@ -1088,12 +1787,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1920, y: 1080}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 1
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -1173,6 +1872,81 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1856869783}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1750033330
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1750033331}
+  - component: {fileID: 1750033333}
+  - component: {fileID: 1750033332}
+  m_Layer: 5
+  m_Name: BackGround
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1750033331
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1750033330}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8983960}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1750033332
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1750033330}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1750033333
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1750033330}
+  m_CullTransparentMesh: 1
 --- !u!1 &1856869782
 GameObject:
   m_ObjectHideFlags: 0
@@ -1214,5 +1988,5 @@ SceneRoots:
   m_Roots:
   - {fileID: 1386235779}
   - {fileID: 1856869783}
-  - {fileID: 302853228}
   - {fileID: 1627674365}
+  - {fileID: 645097904}

--- a/Assets/_Application/Lobby/Scenes/LobbyScene.unity
+++ b/Assets/_Application/Lobby/Scenes/LobbyScene.unity
@@ -872,143 +872,6 @@ RectTransform:
   m_AnchoredPosition: {x: 100, y: -176.36998}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &107057109
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 107057110}
-  - component: {fileID: 107057112}
-  - component: {fileID: 107057111}
-  m_Layer: 5
-  m_Name: Text (TMP)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &107057110
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 107057109}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1953833512}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &107057111
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 107057109}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: SelectCharacter
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_characterHorizontalScale: 1
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: -29.200386, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &107057112
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 107057109}
-  m_CullTransparentMesh: 1
 --- !u!1 &116767376
 GameObject:
   m_ObjectHideFlags: 0
@@ -1995,9 +1858,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -2394,9 +2257,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -2464,9 +2327,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 556703854}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Script: {fileID: 11500000, guid: 57ec942dd21dec94ebf8f2e31cdd3fa7, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Slider
+  m_EditorClassIdentifier: Uraty.Application.Lobby::Uraty.Application.Lobby.ConfirmableSlider
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -2477,9 +2340,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -2506,6 +2369,7 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+  _editingMarker: {fileID: 0}
 --- !u!1 &611860597
 GameObject:
   m_ObjectHideFlags: 0
@@ -3418,9 +3282,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 801150688}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Script: {fileID: 11500000, guid: 57ec942dd21dec94ebf8f2e31cdd3fa7, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Slider
+  m_EditorClassIdentifier: Uraty.Application.Lobby::Uraty.Application.Lobby.ConfirmableSlider
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3431,9 +3295,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -3460,6 +3324,7 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+  _editingMarker: {fileID: 0}
 --- !u!1 &830494750
 GameObject:
   m_ObjectHideFlags: 0
@@ -3575,6 +3440,8 @@ MonoBehaviour:
   - {fileID: 11400000, guid: d6ae1d0c2fcba9c4a86a9c68f838cab1, type: 2}
   - {fileID: 11400000, guid: fc965c2346768014390c3459858c681d, type: 2}
   - {fileID: 11400000, guid: bf2cc5b92a2f1194295993c69726da28, type: 2}
+  _firstMainSelectable: {fileID: 552126074}
+  _cancelActionReference: {fileID: -5248257707909057152, guid: 0bf1b86489f9fc34aaa77cac93ad435f, type: 3}
 --- !u!4 &847364622
 Transform:
   m_ObjectHideFlags: 0
@@ -3844,18 +3711,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 4
     m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
+    m_SelectOnUp: {fileID: 913897043}
+    m_SelectOnDown: {fileID: 1240417471}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -3923,22 +3790,22 @@ MonoBehaviour:
   m_GameObject: {fileID: 913897041}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Script: {fileID: 11500000, guid: 57ec942dd21dec94ebf8f2e31cdd3fa7, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Slider
+  m_EditorClassIdentifier: Uraty.Application.Lobby::Uraty.Application.Lobby.ConfirmableSlider
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 4
     m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
+    m_SelectOnUp: {fileID: 801150690}
+    m_SelectOnDown: {fileID: 907844667}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -3965,6 +3832,7 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+  _editingMarker: {fileID: 0}
 --- !u!1 &921231806
 GameObject:
   m_ObjectHideFlags: 0
@@ -4276,9 +4144,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 0.8431373, b: 0, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -4969,7 +4837,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1240417470}
-  - component: {fileID: 1240417469}
+  - component: {fileID: 1240417471}
   m_Layer: 5
   m_Name: BgmVolumeSlider
   m_TagString: Untagged
@@ -4977,7 +4845,29 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1240417469
+--- !u!224 &1240417470
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1240417468}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 4.2095, y: 4.2095, z: 4.2095}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 921231807}
+  - {fileID: 2069754307}
+  - {fileID: 2123585130}
+  m_Father: {fileID: 1526723566}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1240417471
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4986,9 +4876,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1240417468}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Script: {fileID: 11500000, guid: 57ec942dd21dec94ebf8f2e31cdd3fa7, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Slider
+  m_EditorClassIdentifier: Uraty.Application.Lobby::Uraty.Application.Lobby.ConfirmableSlider
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -4999,9 +4889,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -5028,28 +4918,7 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
---- !u!224 &1240417470
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1240417468}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 4.2095, y: 4.2095, z: 4.2095}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 921231807}
-  - {fileID: 2069754307}
-  - {fileID: 2123585130}
-  m_Father: {fileID: 1526723566}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 20}
-  m_Pivot: {x: 0.5, y: 0.5}
+  _editingMarker: {fileID: 0}
 --- !u!1 &1263680173
 GameObject:
   m_ObjectHideFlags: 0
@@ -5161,6 +5030,143 @@ RectTransform:
   m_AnchoredPosition: {x: -5, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1358979280
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1358979281}
+  - component: {fileID: 1358979283}
+  - component: {fileID: 1358979282}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1358979281
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1358979280}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1953833512}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1358979282
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1358979280}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1358979283
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1358979280}
+  m_CullTransparentMesh: 1
 --- !u!1 &1375033017
 GameObject:
   m_ObjectHideFlags: 0
@@ -5558,9 +5564,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1472273591}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Script: {fileID: 11500000, guid: 57ec942dd21dec94ebf8f2e31cdd3fa7, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Slider
+  m_EditorClassIdentifier: Uraty.Application.Lobby::Uraty.Application.Lobby.ConfirmableSlider
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -5571,9 +5577,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -5600,6 +5606,7 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+  _editingMarker: {fileID: 0}
 --- !u!1 &1516936243
 GameObject:
   m_ObjectHideFlags: 0
@@ -5795,6 +5802,7 @@ MonoBehaviour:
   _characterNameText: {fileID: 0}
   _characterSelectSceneName: LobbyCharacterSelectScene
   _characterSelectionStore: {fileID: 11400000, guid: 6e4d667cd6baba6438ef866126af715e, type: 2}
+  _returnSelectable: {fileID: 1953833513}
 --- !u!4 &1633101552
 Transform:
   m_ObjectHideFlags: 0
@@ -5849,13 +5857,16 @@ MonoBehaviour:
   _keyMouseDeadZoneSlider: {fileID: 1472273593}
   _stickDeadZoneSlider: {fileID: 913897043}
   _seVolumeSlider: {fileID: 556703856}
-  _bgmVolumeSlider: {fileID: 1240417469}
+  _bgmVolumeSlider: {fileID: 1240417471}
   _mouseSensitivityValueText: {fileID: 614551373}
   _stickSensitivityValueText: {fileID: 966717389}
   _keyMouseDeadZoneValueText: {fileID: 1789427166}
   _stickDeadZoneValueText: {fileID: 928235825}
   _seVolumeValueText: {fileID: 1452408053}
   _bgmVolumeValueText: {fileID: 2136843552}
+  _firstMainSelectable: {fileID: 431892446}
+  _firstSettingSelectable: {fileID: 1240417471}
+  _cancelActionReference: {fileID: -5248257707909057152, guid: 0bf1b86489f9fc34aaa77cac93ad435f, type: 3}
 --- !u!4 &1641482075
 Transform:
   m_ObjectHideFlags: 0
@@ -6167,9 +6178,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1852969746}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Script: {fileID: 11500000, guid: 57ec942dd21dec94ebf8f2e31cdd3fa7, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Slider
+  m_EditorClassIdentifier: Uraty.Application.Lobby::Uraty.Application.Lobby.ConfirmableSlider
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -6180,9 +6191,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.1960784, g: 0.8039216, b: 0.1960784, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -6209,6 +6220,7 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+  _editingMarker: {fileID: 0}
 --- !u!1 &1854481041
 GameObject:
   m_ObjectHideFlags: 0
@@ -6619,13 +6631,13 @@ RectTransform:
   m_LocalScale: {x: 2.6706, y: 2.6706, z: 2.6706}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 107057110}
+  - {fileID: 1358979281}
   m_Father: {fileID: 1227536549}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 30}
+  m_SizeDelta: {x: 200, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1953833513
 MonoBehaviour:
@@ -6649,9 +6661,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 0.6313726}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 0.7647059}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -6684,7 +6696,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 0.1254902, g: 0.1254902, b: 0.1254902, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -6786,9 +6798,9 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_HighlightedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0.8627452, g: 0.07843138, b: 0.2352941, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1

--- a/Assets/_Application/Lobby/Scripts/CharacterPreviewSelectable.cs
+++ b/Assets/_Application/Lobby/Scripts/CharacterPreviewSelectable.cs
@@ -1,46 +1,29 @@
 using UnityEngine;
 
-using Uraty.Feature.Akane_TestCharacter;
-
 namespace Uraty.Application.Lobby
 {
     /// <summary>
     /// キャラ選択画面で表示される3Dキャラの選択状態を管理するクラス。
-    /// どのCharacterDataに対応しているかを保持し、選択中なら見た目を少し大きくする。
     /// </summary>
     public sealed class CharacterPreviewSelectable : MonoBehaviour
     {
         // 選択されていない通常時のスケール。
         private Vector3 _defaultScale;
 
-        /// <summary>
-        /// この表示キャラに対応するキャラデータ。
-        /// </summary>
-        public CharacterData Character
+        public int Index
         {
             get; private set;
         }
 
-        /// <summary>
-        /// キャラ生成後に、対応するCharacterDataを登録する。
-        /// </summary>
-        public void Initialize(CharacterData character)
+        private void Awake()
         {
-            Character = character;
-
-            // 選択状態を戻すために、初期スケールを保存しておく。
             _defaultScale = transform.localScale;
         }
 
-        /// <summary>
-        /// 選択状態に応じて見た目を変える。
-        /// 現状は選択中なら少し大きくする。
-        /// </summary>
-        public void SetSelected(bool isSelected, float selectedScale)
+        public void Initialize(int index)
         {
-            transform.localScale = isSelected
-                ? _defaultScale * selectedScale
-                : _defaultScale;
+            Index = index;
+            _defaultScale = transform.localScale;
         }
     }
 }

--- a/Assets/_Application/Lobby/Scripts/CharacterSelectSceneController.cs
+++ b/Assets/_Application/Lobby/Scripts/CharacterSelectSceneController.cs
@@ -3,243 +3,623 @@ using System.Collections.Generic;
 using TMPro;
 
 using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 using Uraty.Feature.Akane_TestCharacter;
+using Uraty.Features.Character;
 using Uraty.Systems.Input;
 
 namespace Uraty.Application.Lobby
 {
     /// <summary>
-    /// Additiveで読み込まれるキャラ選択シーンを管理するクラス。
-    /// キャラPrefabの生成、クリック選択、決定、シーンを閉じる処理を担当する。
+    /// キャラ選択画面を管理するクラス。
+    /// 3Dキャラモデルを横並びで表示し、中央のキャラを選択中として扱う。
     /// </summary>
     public sealed class CharacterSelectSceneController : MonoBehaviour
     {
         [Header("Input")]
         // 入力管理クラス。
-        // Inspectorで未設定の場合は、StartでHierarchy上から探す。
+        // 未設定の場合はStartでHierarchy上から探す。
         [SerializeField] private GameInput _gameInput;
+
+        [Header("Store")]
+        // ロビーとキャラ選択画面で共有する選択キャラStore。
+        [SerializeField] private CharacterSelectionStore _characterSelectionStore;
 
         [Header("Characters")]
         // キャラ選択画面に表示するキャラデータ一覧。
-        [SerializeField] private CharacterData[] _characters;
+        [SerializeField] private GameObject[] _characterPrefabs;
 
-        [Header("Preview Slots")]
-        // 各キャラPrefabを生成する位置。
-        // Characters配列と順番を合わせる。
-        [SerializeField] private Transform[] _previewSlots;
+        [Header("Preview")]
+        // 3Dキャラモデルを横並びで生成する親。
+        [SerializeField] private Transform _carouselRoot;
 
-        [Header("View")]
-        // 現在選択中のキャラ名を表示するText。
-        [SerializeField] private TextMeshProUGUI _selectedCharacterNameText;
+        // 3Dキャラ選択用のCamera。
+        [SerializeField] private Camera _selectCamera;
 
-        [Header("Buttons")]
+        // キャラ同士の横間隔。
+        [SerializeField] private float _slotSpacing = 2.5f;
+
+        // 選択中キャラが中央へ移動する速度。
+        [SerializeField] private float _moveSpeed = 10.0f;
+
+        // 3Dモデルクリック判定用Rayの距離。
+        [SerializeField] private float _rayDistance = 1000.0f;
+
+        [Header("Scale")]
+        // 選択中キャラの左右に何体まで表示するか。
+        [SerializeField] private int _visibleSideCount = 2;
+
+        // 中央の選択中キャラの拡大率。
+        [SerializeField] private float _selectedScale = 1.4f;
+
+        // 選択中キャラの隣にいるキャラの拡大率。
+        [SerializeField] private float _nearSideScale = 1.0f;
+
+        // 選択中キャラから2つ離れたキャラの拡大率。
+        [SerializeField] private float _farSideScale = 0.75f;
+
+        [Header("UI")]
+        // 選択中キャラ名を表示するText。
+        [SerializeField] private TextMeshProUGUI _characterNameText;
+
+        // 選択中キャラの説明文を表示するText。
+        [SerializeField] private TextMeshProUGUI _characterDescriptionText;
+
         // 選択中キャラを確定するボタン。
         [SerializeField] private Button _decideButton;
 
         // キャラ選択画面を閉じるボタン。
         [SerializeField] private Button _closeButton;
 
-        [Header("Selection")]
-        // 選択中キャラをどれくらい大きく見せるか。
-        [SerializeField] private float _selectedScale = 2f;
+        [Header("Drag")]
+        // この値以上左右に動かしたらキャラを切り替える。
+        [SerializeField] private float _dragThreshold = 80.0f;
 
-        // Raycastの最大距離。
-        [SerializeField] private float _rayDistance = 1000f;
+        [Header("Gamepad")]
+        // ゲームパッド左右入力を受け付けるしきい値。
+        [SerializeField] private float _gamepadInputThreshold = 0.6f;
 
-        [Header("Camera")]
-        // キャラ選択用のCamera。
-        // 未設定の場合はCamera.mainを使う。
-        [SerializeField] private Camera _selectCamera;
+        // ゲームパッド長押し時の連続切り替え間隔。
+        [SerializeField] private float _gamepadRepeatSeconds = 0.25f;
 
-        [Header("Store")]
-        [SerializeField] private CharacterSelectionStore _characterSelectionStore;
+        [Header("Mouse")]
+        [SerializeField] private GameObject _dragArea;
 
-        // 生成したキャラ選択用オブジェクトを保持するリスト。
-        // 選択状態の更新に使う。
-        private readonly List<CharacterPreviewSelectable> _selectables = new();
+        [Header("Default Selection")]
+        [SerializeField] private Selectable _firstSelectable;
 
-        // 現在選択中のキャラデータ。
-        private CharacterData _selectedCharacter;
+        private enum CharacterSlideDirection
+        {
+            None,
+            Next,
+            Previous
+        }
+
+        // 生成したキャラ表示オブジェクトの状態一覧。
+        private readonly List<CharacterPreviewState> _previewStates = new();
+
+        // 現在選択中のIndex。
+        private int _selectedIndex;
+
+        private sealed class CharacterPreviewState
+        {
+            public CharacterPreviewState(
+                GameObject sourcePrefab,
+                CharacterPreviewSelectable selectable,
+                CharacterStatus status,
+                CharacterAttack attack,
+                CharacterSuper characterSuper,
+                Vector3 targetLocalPosition,
+                float targetScale)
+            {
+                SourcePrefab = sourcePrefab;
+                Selectable = selectable;
+                Status = status;
+                Attack = attack;
+                CharacterSuper = characterSuper;
+                TargetLocalPosition = targetLocalPosition;
+                TargetScale = targetScale;
+                IsActiveDuringMove = false;
+                IsVisibleAfterMove = false;
+            }
+
+            public GameObject SourcePrefab
+            {
+                get;
+            }
+
+            public CharacterPreviewSelectable Selectable
+            {
+                get;
+            }
+
+            public CharacterStatus Status
+            {
+                get;
+            }
+
+            public CharacterAttack Attack
+            {
+                get;
+            }
+
+            public CharacterSuper CharacterSuper
+            {
+                get;
+            }
+
+            public string DisplayName =>
+                SourcePrefab != null ? SourcePrefab.name : "未設定";
+
+            public Vector3 TargetLocalPosition
+            {
+                get; set;
+            }
+
+            public float TargetScale
+            {
+                get; set;
+            }
+
+            public bool IsActiveDuringMove
+            {
+                get; set;
+            }
+
+            public bool IsVisibleAfterMove
+            {
+                get; set;
+            }
+        }
+
+        // 次にゲームパッド入力を受け付ける時刻。
+        private float _nextGamepadInputTime;
+
+        // マウスドラッグ中かどうか。
+        private bool _isMouseDragging;
+
+        // 今回のマウス操作でドラッグによる切り替えが発生したか。
+        private bool _hasMouseDragged;
+
+        // マウスドラッグ開始位置。
+        private Vector2 _mouseDragStartPosition;
 
         private void Awake()
         {
+            // 自身の内部初期化として、キャラ表示を生成する。
             CreateCharacterPreviews();
         }
 
         private void OnEnable()
         {
-            _decideButton.onClick.AddListener(Decide);
-            _closeButton.onClick.AddListener(Close);
+            // ボタンの登録。
+            if (_decideButton != null)
+            {
+                _decideButton.onClick.AddListener(HandleDecideButtonClicked);
+            }
+
+            if (_closeButton != null)
+            {
+                _closeButton.onClick.AddListener(HandleCloseButtonClicked);
+            }
         }
 
         private void Start()
         {
+            // 他オブジェクト依存の入力取得。
             if (_gameInput == null)
             {
                 _gameInput = FindFirstObjectByType<GameInput>();
             }
 
-            if (_gameInput == null)
+            if (_gameInput != null)
             {
-                Debug.LogError("GameInput が見つかりません。Systemsシーンなどに GameInput を配置してください。");
-                return;
+                _gameInput.EnableUIInput();
             }
 
-            _gameInput.EnableUIInput();
-
+            // Storeに保存されているキャラ、または先頭キャラを初期選択にする。
             ApplyInitialSelection();
+
+            // 初期選択状態を見た目と説明文に反映する。
+            RefreshSelection();
+            ApplyPreviewStatesImmediately();
+
+            // パッド操作用に最初のUIを選択する。
+            SelectUi(_firstSelectable);
         }
 
         private void Update()
         {
-            if (_gameInput == null)
-            {
-                return;
-            }
+            // 選択中キャラが中央に来るように、親を少しずつ移動する。
+            MoveCharacterPreviews();
 
-            // Cancel入力でキャラ選択画面を閉じる。
-            if (_gameInput.UI.Cancel.WasPressedThisFrame())
-            {
-                Close();
-                return;
-            }
+            // Cancelでキャラ選択画面を閉じる。
+            HandleCancelInput();
 
-            // Submit入力で、ポインタ位置から3Dキャラを選択する。
-            if (_gameInput.UI.Submit.WasPressedThisFrame())
-            {
-                TrySelectCharacterByPoint();
-            }
+            // ゲームパッドの左右入力。
+            HandleGamepadInput();
+
+            // マウスのドラッグ / クリック入力。
+            HandleMouseInput();
         }
 
         private void OnDisable()
         {
+            // ボタンの解除。
             if (_decideButton != null)
             {
-                _decideButton.onClick.RemoveListener(Decide);
+                _decideButton.onClick.RemoveListener(HandleDecideButtonClicked);
             }
 
             if (_closeButton != null)
             {
-                _closeButton.onClick.RemoveListener(Close);
-            }
-        }
-
-        private void ApplyInitialSelection()
-        {
-            if (_characterSelectionStore == null)
-            {
-                Debug.LogError("CharacterSelectionStore が設定されていません。");
-                return;
-            }
-
-            CharacterData currentCharacter = _characterSelectionStore.SelectedCharacter;
-
-            if (currentCharacter != null)
-            {
-                SelectCharacter(currentCharacter);
-                return;
-            }
-
-            if (_characters != null && _characters.Length > 0)
-            {
-                SelectCharacter(_characters[0]);
+                _closeButton.onClick.RemoveListener(HandleCloseButtonClicked);
             }
         }
 
         /// <summary>
-        /// CharacterData配列をもとに、各SlotへキャラPrefabを生成する。
+        /// CharacterData配列から3Dキャラモデルを生成する。
         /// </summary>
         private void CreateCharacterPreviews()
         {
-            if (_characters == null || _characters.Length == 0)
+            if (_characterPrefabs == null || _characterPrefabs.Length == 0)
             {
-                Debug.LogWarning("Characters が設定されていません。");
+                Debug.LogWarning("Character Prefabs が設定されていません。");
                 return;
             }
 
-            if (_previewSlots == null || _previewSlots.Length == 0)
+            if (_carouselRoot == null)
             {
-                Debug.LogWarning("Preview Slots が設定されていません。");
+                Debug.LogWarning("CarouselRoot が設定されていません。");
                 return;
             }
 
-            // キャラ数とSlot数の少ない方に合わせる。
-            int count = Mathf.Min(_characters.Length, _previewSlots.Length);
-
-            for (int i = 0; i < count; i++)
+            for (int i = 0; i < _characterPrefabs.Length; i++)
             {
-                CharacterData character = _characters[i];
-                Transform slot = _previewSlots[i];
+                GameObject characterPrefab = _characterPrefabs[i];
 
-                if (character == null || slot == null)
+                if (characterPrefab == null)
                 {
                     continue;
                 }
 
-                if (character.PreviewPrefab == null)
-                {
-                    Debug.LogWarning($"{character.DisplayName} に PreviewPrefab が設定されていません。");
-                    continue;
-                }
-
-                // Slotの位置にキャラPrefabを生成する。
                 GameObject previewObject = Instantiate(
-                    character.PreviewPrefab,
-                    slot.position,
-                    slot.rotation,
-                    slot
+                    characterPrefab,
+                    _carouselRoot
                 );
 
-                // クリック選択用のComponentを取得する。
+                previewObject.transform.localPosition = new Vector3(
+                    i * _slotSpacing,
+                    0.0f,
+                    0.0f
+                );
+
+                previewObject.transform.localRotation = Quaternion.identity;
+
                 CharacterPreviewSelectable selectable =
                     previewObject.GetComponent<CharacterPreviewSelectable>();
 
-                // Prefab側に付いていない場合は、自動で追加する。
                 if (selectable == null)
                 {
                     selectable = previewObject.AddComponent<CharacterPreviewSelectable>();
                 }
 
-                // この表示キャラがどのCharacterDataに対応するかを登録する。
-                selectable.Initialize(character);
+                selectable.Initialize(i);
 
-                // 選択状態の更新用に保持する。
-                _selectables.Add(selectable);
+                CharacterStatus status =
+                    previewObject.GetComponentInChildren<CharacterStatus>(true);
+
+                CharacterAttack attack =
+                    previewObject.GetComponentInChildren<CharacterAttack>(true);
+
+                CharacterSuper characterSuper =
+                    previewObject.GetComponentInChildren<CharacterSuper>(true);
+
+                _previewStates.Add(
+                    new CharacterPreviewState(
+                        characterPrefab,
+                        selectable,
+                        status,
+                        attack,
+                        characterSuper,
+                        previewObject.transform.localPosition,
+                        _farSideScale
+                    )
+                );
             }
         }
 
         /// <summary>
-        /// 現在のポインタ位置からRayを飛ばし、当たったキャラを選択する。
+        /// Storeに保存されているキャラを初期選択にする。
+        /// 未保存の場合は先頭キャラを選択する。
         /// </summary>
-        private void TrySelectCharacterByPoint()
+        private void ApplyInitialSelection()
         {
-            // 専用Cameraが設定されていればそれを使う。
-            // 未設定ならCamera.mainを使う。
-            Camera mainCamera = _selectCamera != null ? _selectCamera : Camera.main;
+            if (_previewStates.Count == 0)
+            {
+                return;
+            }
 
-            if (mainCamera == null)
+            if (_characterSelectionStore == null)
+            {
+                _selectedIndex = 0;
+                return;
+            }
+
+            GameObject selectedCharacterPrefab =
+                _characterSelectionStore.SelectedCharacterPrefab;
+
+            for (int i = 0; i < _previewStates.Count; i++)
+            {
+                if (_previewStates[i].SourcePrefab == selectedCharacterPrefab)
+                {
+                    _selectedIndex = i;
+                    return;
+                }
+            }
+
+            _selectedIndex = 0;
+        }
+
+        /// <summary>
+        /// 各キャラを目標位置・目標スケールへ少しずつ近づける。
+        /// </summary>
+        private void MoveCharacterPreviews()
+        {
+            for (int i = 0; i < _previewStates.Count; i++)
+            {
+                CharacterPreviewState previewState = _previewStates[i];
+
+                if (previewState == null || previewState.Selectable == null)
+                {
+                    continue;
+                }
+
+                GameObject previewObject = previewState.Selectable.gameObject;
+
+                if (!previewState.IsActiveDuringMove)
+                {
+                    if (previewObject.activeSelf)
+                    {
+                        previewObject.SetActive(false);
+                    }
+
+                    continue;
+                }
+
+                if (!previewObject.activeSelf)
+                {
+                    previewObject.SetActive(true);
+                }
+
+                Transform previewTransform = previewState.Selectable.transform;
+
+                previewTransform.localPosition = Vector3.Lerp(
+                    previewTransform.localPosition,
+                    previewState.TargetLocalPosition,
+                    Time.deltaTime * _moveSpeed
+                );
+
+                previewTransform.localScale = Vector3.Lerp(
+                    previewTransform.localScale,
+                    Vector3.one * previewState.TargetScale,
+                    Time.deltaTime * _moveSpeed
+                );
+            }
+        }
+
+        /// <summary>
+        /// マウスの左右ドラッグとクリック選択を処理する。
+        /// UIイベントのOnDragに頼らず、Mouse.currentから直接読む。
+        /// </summary>
+        private void HandleMouseInput()
+        {
+            if (Mouse.current == null || EventSystem.current == null)
+            {
+                return;
+            }
+
+            Vector2 mousePosition = Mouse.current.position.ReadValue();
+
+            if (Mouse.current.leftButton.wasPressedThisFrame)
+            {
+                Debug.Log($"Mouse pressed: {mousePosition}");
+
+                if (!IsPointerOverDragArea(mousePosition))
+                {
+                    Debug.Log("DragArea上ではありません。");
+                    return;
+                }
+
+                Debug.Log("Mouse drag start");
+
+                _isMouseDragging = true;
+                _hasMouseDragged = false;
+                _mouseDragStartPosition = mousePosition;
+
+                return;
+            }
+
+            if (!_isMouseDragging)
+            {
+                return;
+            }
+
+            if (Mouse.current.leftButton.isPressed)
+            {
+                float dragAmount = mousePosition.x - _mouseDragStartPosition.x;
+
+                Debug.Log($"Mouse drag amount: {dragAmount}");
+
+                if (Mathf.Abs(dragAmount) < _dragThreshold)
+                {
+                    return;
+                }
+
+                if (dragAmount < 0.0f)
+                {
+                    Debug.Log("Mouse SelectNext");
+                    SelectNext();
+                }
+                else
+                {
+                    Debug.Log("Mouse SelectPrevious");
+                    SelectPrevious();
+                }
+
+                _mouseDragStartPosition = mousePosition;
+                _hasMouseDragged = true;
+
+                return;
+            }
+
+            if (Mouse.current.leftButton.wasReleasedThisFrame)
+            {
+                Debug.Log("Mouse released");
+
+                if (!_hasMouseDragged)
+                {
+                    TrySelectCharacterByScreenPosition(mousePosition);
+                }
+
+                _isMouseDragging = false;
+            }
+        }
+
+        private bool IsPointerOverDragArea(Vector2 screenPosition)
+        {
+            if (_dragArea == null)
+            {
+                Debug.LogError("DragArea が設定されていません。");
+                return false;
+            }
+
+            PointerEventData pointerEventData = new PointerEventData(EventSystem.current)
+            {
+                position = screenPosition
+            };
+
+            List<RaycastResult> raycastResults = new();
+            EventSystem.current.RaycastAll(pointerEventData, raycastResults);
+
+            foreach (RaycastResult raycastResult in raycastResults)
+            {
+                Debug.Log($"UI Raycast Hit: {raycastResult.gameObject.name}");
+
+                if (raycastResult.gameObject == _dragArea)
+                {
+                    return true;
+                }
+
+                if (raycastResult.gameObject.transform.IsChildOf(_dragArea.transform))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 現在のマウス位置が、このControllerが付いている操作エリア上にあるか調べる。
+        /// </summary>
+        private bool IsPointerOverControlArea(Vector2 screenPosition)
+        {
+            PointerEventData pointerEventData = new PointerEventData(EventSystem.current)
+            {
+                position = screenPosition
+            };
+
+            List<RaycastResult> raycastResults = new();
+            EventSystem.current.RaycastAll(pointerEventData, raycastResults);
+
+            foreach (RaycastResult raycastResult in raycastResults)
+            {
+                // CharacterSelectSceneControllerがDragAreaに付いている前提。
+                if (raycastResult.gameObject == gameObject)
+                {
+                    return true;
+                }
+
+                if (raycastResult.gameObject.transform.IsChildOf(transform))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// ゲームパッドの左右入力でキャラを切り替える。
+        /// </summary>
+        private void HandleGamepadInput()
+        {
+            if (_gameInput == null)
+            {
+                return;
+            }
+
+            if (!IsCharacterFocusSelected())
+            {
+                return;
+            }
+
+            if (Time.unscaledTime < _nextGamepadInputTime)
+            {
+                return;
+            }
+
+            Vector2 navigate = _gameInput.UI.Navigate.ReadValue<Vector2>();
+
+            if (navigate.x > _gamepadInputThreshold)
+            {
+                SelectNext();
+                _nextGamepadInputTime = Time.unscaledTime + _gamepadRepeatSeconds;
+                return;
+            }
+
+            if (navigate.x < -_gamepadInputThreshold)
+            {
+                SelectPrevious();
+                _nextGamepadInputTime = Time.unscaledTime + _gamepadRepeatSeconds;
+            }
+        }
+
+        private void HandleCancelInput()
+        {
+            if (_gameInput == null)
+            {
+                return;
+            }
+
+            if (!_gameInput.UI.Cancel.WasPressedThisFrame())
+            {
+                return;
+            }
+
+            HandleCloseButtonClicked();
+        }
+
+        /// <summary>
+        /// 画面座標から3D空間へRayを飛ばし、クリックされたキャラを選択する。
+        /// </summary>
+        private void TrySelectCharacterByScreenPosition(Vector2 screenPosition)
+        {
+            Camera selectCamera = _selectCamera != null ? _selectCamera : Camera.main;
+
+            if (selectCamera == null)
             {
                 Debug.LogWarning("選択用Cameraが見つかりません。");
                 return;
             }
 
-            // GameInputのUI/Pointから、画面上のポインタ座標を取得する。
-            Vector2 pointerPosition = _gameInput.UI.Point.ReadValue<Vector2>();
+            Ray ray = selectCamera.ScreenPointToRay(screenPosition);
 
-            Debug.Log($"Pointer Position: {pointerPosition}");
-            Debug.Log($"Screen Size: {Screen.width}, {Screen.height}");
-
-            // 画面座標から3D空間へRayを飛ばす。
-            Ray ray = mainCamera.ScreenPointToRay(pointerPosition);
-
-            // Sceneビュー上でRayの方向を確認するためのデバッグ表示。
-            Debug.DrawRay(ray.origin, ray.direction * _rayDistance, Color.red, 2f);
-
-            // Rayに当たったすべてのColliderを取得する。
-            // Triggerも対象にするため、QueryTriggerInteraction.Collideを指定している。
             RaycastHit[] hits = Physics.RaycastAll(
                 ray,
                 _rayDistance,
@@ -249,17 +629,14 @@ namespace Uraty.Application.Lobby
 
             if (hits.Length == 0)
             {
-                Debug.Log("Raycastが何にも当たっていません。");
                 return;
             }
 
-            // どのColliderに当たったか確認するためのログ。
-            foreach (RaycastHit hit in hits)
-            {
-                Debug.Log($"Raycast hit: {hit.collider.name}");
-            }
+            System.Array.Sort(
+                hits,
+                (left, right) => left.distance.CompareTo(right.distance)
+            );
 
-            // 当たったColliderの親からCharacterPreviewSelectableを探す。
             foreach (RaycastHit hit in hits)
             {
                 CharacterPreviewSelectable selectable =
@@ -270,56 +647,386 @@ namespace Uraty.Application.Lobby
                     continue;
                 }
 
-                // 対応するキャラを選択状態にする。
-                SelectCharacter(selectable.Character);
+                SelectIndex(selectable.Index);
                 return;
             }
-
-            Debug.Log("Rayは何かに当たったが、CharacterPreviewSelectable は見つかりませんでした。");
         }
 
         /// <summary>
-        /// 指定されたキャラを選択中キャラとして扱う。
-        /// 表示名と選択中の見た目も更新する。
+        /// 1つ右側のキャラを選択する。
         /// </summary>
-        private void SelectCharacter(CharacterData character)
+        private void SelectNext()
         {
-            if (character == null)
+            if (_previewStates.Count == 0)
             {
                 return;
             }
 
-            _selectedCharacter = character;
+            SelectIndex(_selectedIndex + 1, CharacterSlideDirection.Next);
+        }
 
-            // 選択中キャラ名をUIに表示する。
-            if (_selectedCharacterNameText != null)
+        /// <summary>
+        /// 1つ左側のキャラを選択する。
+        /// </summary>
+        private void SelectPrevious()
+        {
+            if (_previewStates.Count == 0)
             {
-                _selectedCharacterNameText.text = character.DisplayName;
+                return;
             }
 
-            // 全キャラの選択状態を更新する。
-            foreach (CharacterPreviewSelectable selectable in _selectables)
+            SelectIndex(_selectedIndex - 1, CharacterSlideDirection.Previous);
+        }
+
+        private void SelectIndex(int index)
+        {
+            SelectIndex(index, CharacterSlideDirection.None);
+        }
+
+        /// <summary>
+        /// 指定Indexのキャラを選択する。
+        /// 範囲外の場合はループさせる。
+        /// </summary>
+        private void SelectIndex(int index, CharacterSlideDirection slideDirection)
+        {
+            if (_previewStates.Count == 0)
             {
-                if (selectable == null)
+                return;
+            }
+
+            int previousIndex = _selectedIndex;
+            int nextIndex = WrapIndex(index, _previewStates.Count);
+
+            if (previousIndex == nextIndex)
+            {
+                return;
+            }
+
+            PrepareSlideStartPositions(previousIndex, nextIndex, slideDirection);
+
+            _selectedIndex = nextIndex;
+
+            RefreshSelectionTargets(previousIndex, slideDirection);
+            RefreshCharacterInfo();
+        }
+
+        private int WrapIndex(int index, int count)
+        {
+            if (count <= 0)
+            {
+                return 0;
+            }
+
+            return (index % count + count) % count;
+        }
+
+        /// <summary>
+        /// 選択状態に応じて、各キャラの目標位置・表示状態・説明文を更新する。
+        /// </summary>
+        private void RefreshSelection()
+        {
+            RefreshSelectionTargets(_selectedIndex, CharacterSlideDirection.None);
+            RefreshCharacterInfo();
+        }
+
+        private void RefreshSelectionTargets(
+            int previousIndex,
+            CharacterSlideDirection slideDirection)
+        {
+            int visibleSideCount = GetVisibleSideCount();
+
+            for (int i = 0; i < _previewStates.Count; i++)
+            {
+                CharacterPreviewState previewState = _previewStates[i];
+
+                if (previewState == null || previewState.Selectable == null)
                 {
                     continue;
                 }
 
-                bool isSelected = selectable.Character == character;
-                selectable.SetSelected(isSelected, _selectedScale);
+                int rightDistance = GetRightDistance(
+                    _selectedIndex,
+                    i,
+                    _previewStates.Count
+                );
+
+                bool finalVisible = rightDistance <= visibleSideCount;
+
+                int targetSlot = finalVisible
+                    ? rightDistance
+                    : visibleSideCount + 1;
+
+                previewState.TargetLocalPosition = new Vector3(
+                    targetSlot * _slotSpacing,
+                    0.0f,
+                    0.0f
+                );
+
+                previewState.TargetScale = GetScaleBySlot(targetSlot);
+                previewState.IsActiveDuringMove = finalVisible;
+                previewState.IsVisibleAfterMove = finalVisible;
+
+                previewState.Selectable.gameObject.SetActive(finalVisible);
+            }
+        }
+
+        private int GetRightDistance(int selectedIndex, int targetIndex, int count)
+        {
+            if (count <= 0)
+            {
+                return 0;
             }
 
-            Debug.Log($"選択中キャラ: {character.DisplayName}");
+            return (targetIndex - selectedIndex + count) % count;
+        }
+
+        private bool IsVisibleFromSelectedIndex(int selectedIndex, int targetIndex)
+        {
+            int rightDistance = GetRightDistance(
+                selectedIndex,
+                targetIndex,
+                _previewStates.Count
+            );
+
+            return rightDistance <= GetVisibleSideCount();
+        }
+
+        private int GetVisibleSideCount()
+        {
+            return Mathf.Max(0, _visibleSideCount);
+        }
+
+        private float GetScaleBySlot(int slot)
+        {
+            int distance = Mathf.Abs(slot);
+
+            return GetScaleByDistance(distance);
+        }
+
+        private void PrepareSlideStartPositions(
+            int previousIndex,
+            int nextIndex,
+            CharacterSlideDirection slideDirection)
+        {
+            if (_previewStates.Count == 0)
+            {
+                return;
+            }
+
+            int visibleSideCount = GetVisibleSideCount();
+
+            if (slideDirection == CharacterSlideDirection.Previous)
+            {
+                SetPreviewStartTransform(
+                    nextIndex,
+                    -_slotSpacing,
+                    _farSideScale
+                );
+
+                return;
+            }
+
+            if (slideDirection == CharacterSlideDirection.Next)
+            {
+                int enteringRightIndex = WrapIndex(
+                    nextIndex + visibleSideCount,
+                    _previewStates.Count
+                );
+
+                if (enteringRightIndex == previousIndex)
+                {
+                    return;
+                }
+
+                SetPreviewStartTransform(
+                    enteringRightIndex,
+                    (visibleSideCount + 1) * _slotSpacing,
+                    _farSideScale
+                );
+            }
+        }
+
+        private void SetPreviewStartTransform(int index, float localX, float scale)
+        {
+            if (index < 0 || index >= _previewStates.Count)
+            {
+                return;
+            }
+
+            CharacterPreviewState previewState = _previewStates[index];
+
+            if (previewState == null || previewState.Selectable == null)
+            {
+                return;
+            }
+
+            GameObject previewObject = previewState.Selectable.gameObject;
+            Transform previewTransform = previewState.Selectable.transform;
+
+            previewObject.SetActive(true);
+
+            previewTransform.localPosition = new Vector3(
+                localX,
+                0.0f,
+                0.0f
+            );
+
+            previewTransform.localScale = Vector3.one * scale;
+        }
+
+        private void ApplyPreviewStatesImmediately()
+        {
+            for (int i = 0; i < _previewStates.Count; i++)
+            {
+                CharacterPreviewState previewState = _previewStates[i];
+
+                if (previewState == null || previewState.Selectable == null)
+                {
+                    continue;
+                }
+
+                Transform previewTransform = previewState.Selectable.transform;
+
+                previewTransform.localPosition = previewState.TargetLocalPosition;
+                previewTransform.localScale = Vector3.one * previewState.TargetScale;
+
+                previewState.Selectable.gameObject.SetActive(previewState.IsVisibleAfterMove);
+            }
         }
 
         /// <summary>
-        /// 現在選択中のキャラを確定し、ロビー側へ反映する。
+        /// 選択中Indexからの距離に応じて拡大率を返す。
         /// </summary>
-        private void Decide()
+        private float GetScaleByDistance(int distance)
         {
-            if (_selectedCharacter == null)
+            if (distance == 0)
             {
-                Debug.LogWarning("選択中のキャラがありません。");
+                return _selectedScale;
+            }
+
+            if (distance == 1)
+            {
+                return _nearSideScale;
+            }
+
+            if (distance == 2)
+            {
+                return _farSideScale;
+            }
+
+            return _farSideScale;
+        }
+
+        /// <summary>
+        /// 左側の説明欄に、選択中キャラの名前と説明を表示する。
+        /// </summary>
+        private void RefreshCharacterInfo()
+        {
+            CharacterPreviewState previewState = GetSelectedPreviewState();
+
+            if (previewState == null)
+            {
+                if (_characterNameText != null)
+                {
+                    _characterNameText.text = "未選択";
+                }
+
+                if (_characterDescriptionText != null)
+                {
+                    _characterDescriptionText.text = string.Empty;
+                }
+
+                return;
+            }
+
+            if (_characterNameText != null)
+            {
+                _characterNameText.text = previewState.DisplayName;
+            }
+
+            if (_characterDescriptionText != null)
+            {
+                _characterDescriptionText.text =
+                    CreateCharacterDescription(previewState);
+            }
+        }
+
+        private CharacterPreviewState GetSelectedPreviewState()
+        {
+            if (_selectedIndex < 0 || _selectedIndex >= _previewStates.Count)
+            {
+                return null;
+            }
+
+            return _previewStates[_selectedIndex];
+        }
+
+        private string CreateCharacterDescription(CharacterPreviewState previewState)
+        {
+            CharacterStatus status = previewState.Status;
+
+            float maxHp = status != null ? status.MaxHp : 0f;
+            float maxReloadCount = status != null ? status.MaxReloadCount : 0f;
+            float reloadRecoveryPerSecond =
+                status != null ? status.ReloadRecoveryPerSecond : 0f;
+
+            CharacterSkillPreviewInfo attackInfo =
+                previewState.Attack != null
+                    ? previewState.Attack.PreviewInfo
+                    : default;
+
+            CharacterSkillPreviewInfo superInfo =
+                previewState.CharacterSuper != null
+                    ? previewState.CharacterSuper.PreviewInfo
+                    : default;
+
+            return
+                $"HP: {maxHp:0}\n" +
+                $"リロード数: {maxReloadCount:0}\n" +
+                $"リロード回復: {reloadRecoveryPerSecond:0.##}/秒\n\n" +
+                $"通常攻撃\n{FormatSkillInfo(attackInfo)}\n\n" +
+                $"必殺技\n{FormatSkillInfo(superInfo)}";
+        }
+
+        private string FormatSkillInfo(CharacterSkillPreviewInfo info)
+        {
+            if (!info.IsValid)
+            {
+                return "未設定";
+            }
+
+            return
+                $"弾数: {info.BulletCount}\n" +
+                $"合計ダメージ: {info.TotalDamage:0}\n" +
+                $"射程: {info.MaxRange:0.##}\n" +
+                $"弾速: {info.MaxSpeed:0.##}";
+        }
+
+        /// <summary>
+        /// 現在選択中のCharacterDataを取得する。
+        /// </summary>
+        private GameObject GetSelectedCharacterPrefab()
+        {
+            CharacterPreviewState previewState = GetSelectedPreviewState();
+
+            if (previewState == null)
+            {
+                return null;
+            }
+
+            return previewState.SourcePrefab;
+        }
+
+        /// <summary>
+        /// 選択中キャラを確定してロビー側へ反映する。
+        /// </summary>
+        private void HandleDecideButtonClicked()
+        {
+            GameObject selectedCharacterPrefab = GetSelectedCharacterPrefab();
+
+            if (selectedCharacterPrefab == null)
+            {
+                Debug.LogWarning("選択中のキャラPrefabがありません。");
                 return;
             }
 
@@ -329,19 +1036,60 @@ namespace Uraty.Application.Lobby
                 return;
             }
 
-            _characterSelectionStore.SetSelectedCharacter(_selectedCharacter);
+            _characterSelectionStore.SetSelectedCharacterPrefab(selectedCharacterPrefab);
 
-            Debug.Log($"決定したキャラ: {_selectedCharacter.DisplayName}");
-
-            Close();
+            SceneManager.UnloadSceneAsync(gameObject.scene);
         }
 
         /// <summary>
-        /// このAdditive Sceneを閉じる。
+        /// キャラ選択画面を閉じる。
         /// </summary>
-        private void Close()
+        private void HandleCloseButtonClicked()
         {
             SceneManager.UnloadSceneAsync(gameObject.scene);
+        }
+
+        private bool IsCharacterFocusSelected()
+        {
+            if (_firstSelectable == null)
+            {
+                return false;
+            }
+
+            if (EventSystem.current == null)
+            {
+                return false;
+            }
+
+            GameObject selectedGameObject = EventSystem.current.currentSelectedGameObject;
+
+            if (selectedGameObject == null)
+            {
+                return false;
+            }
+
+            return selectedGameObject == _firstSelectable.gameObject;
+        }
+
+        private void SelectUi(Selectable selectable)
+        {
+            if (selectable == null)
+            {
+                return;
+            }
+
+            if (EventSystem.current == null)
+            {
+                return;
+            }
+
+            if (!selectable.gameObject.activeInHierarchy)
+            {
+                return;
+            }
+
+            EventSystem.current.SetSelectedGameObject(null);
+            EventSystem.current.SetSelectedGameObject(selectable.gameObject);
         }
     }
 }

--- a/Assets/_Application/Lobby/Scripts/ConfirmableSlider.cs
+++ b/Assets/_Application/Lobby/Scripts/ConfirmableSlider.cs
@@ -1,0 +1,136 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace Uraty.Application.Lobby
+{
+    /// <summary>
+    /// 決定後だけ十字キー左右で値を変更できるSlider。
+    /// </summary>
+    public sealed class ConfirmableSlider : Slider, ISubmitHandler, ICancelHandler
+    {
+        [Header("Pad Edit")]
+        [SerializeField] private GameObject _editingMarker;
+
+        private const float _stepRatio = 0.01f;
+        private const float MinimumStepValue = 0.0001f;
+
+        private bool _isEditing;
+        public bool IsEditing => _isEditing;
+
+        public override void OnMove(AxisEventData eventData)
+        {
+            if (_isEditing)
+            {
+                HandleEditingMove(eventData);
+                return;
+            }
+
+            if (eventData.moveDir == MoveDirection.Left ||
+                eventData.moveDir == MoveDirection.Right)
+            {
+                eventData.Use();
+                return;
+            }
+
+            base.OnMove(eventData);
+        }
+
+        public void OnSubmit(BaseEventData eventData)
+        {
+            _isEditing = !_isEditing;
+            RefreshEditingMarker();
+
+            eventData.Use();
+        }
+
+        public void OnCancel(BaseEventData eventData)
+        {
+            if (!_isEditing)
+            {
+                return;
+            }
+
+            _isEditing = false;
+            RefreshEditingMarker();
+
+            eventData.Use();
+        }
+
+        public override void OnDeselect(BaseEventData eventData)
+        {
+            _isEditing = false;
+            RefreshEditingMarker();
+
+            base.OnDeselect(eventData);
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            RefreshEditingMarker();
+        }
+
+        private void HandleEditingMove(AxisEventData eventData)
+        {
+            if (eventData.moveDir == MoveDirection.Left)
+            {
+                AddValue(-GetStepValue());
+                eventData.Use();
+                return;
+            }
+
+            if (eventData.moveDir == MoveDirection.Right)
+            {
+                AddValue(GetStepValue());
+                eventData.Use();
+                return;
+            }
+
+            eventData.Use();
+        }
+
+        private void AddValue(float amount)
+        {
+            if (IsReverseDirection())
+            {
+                amount *= -1f;
+            }
+
+            value = Mathf.Clamp(value + amount, minValue, maxValue);
+        }
+
+        private float GetStepValue()
+        {
+            if (wholeNumbers)
+            {
+                return 1f;
+            }
+
+            float range = maxValue - minValue;
+
+            if (range <= 0f)
+            {
+                return 0f;
+            }
+
+            return Mathf.Max(range * _stepRatio, MinimumStepValue);
+        }
+
+        private bool IsReverseDirection()
+        {
+            return direction == Direction.RightToLeft ||
+                   direction == Direction.TopToBottom;
+        }
+
+        private void RefreshEditingMarker()
+        {
+            if (_editingMarker == null)
+            {
+                return;
+            }
+
+            _editingMarker.SetActive(_isEditing);
+        }
+    }
+}

--- a/Assets/_Application/Lobby/Scripts/ConfirmableSlider.cs.meta
+++ b/Assets/_Application/Lobby/Scripts/ConfirmableSlider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 57ec942dd21dec94ebf8f2e31cdd3fa7

--- a/Assets/_Application/Lobby/Scripts/LobbyCharacterDisplayController.cs
+++ b/Assets/_Application/Lobby/Scripts/LobbyCharacterDisplayController.cs
@@ -6,6 +6,7 @@ using R3;
 using TMPro;
 
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
@@ -15,7 +16,7 @@ namespace Uraty.Application.Lobby
 {
     /// <summary>
     /// ロビー画面中央に、現在選択中のキャラPrefabを表示するクラス。
-    /// キャラを押したら、キャラ選択用Additive Sceneを開く。
+    /// キャラ表示部分を押したら、キャラ選択用Additive Sceneを開く。
     /// </summary>
     public sealed class LobbyCharacterDisplayController : MonoBehaviour
     {
@@ -28,18 +29,21 @@ namespace Uraty.Application.Lobby
         [SerializeField] private GameObject _mainPanel;
 
         // 現在表示中のキャラを押すためのボタン。
-        // 透明ボタンとしてキャラ表示部分に重ねる想定
+        // 透明ボタンとしてキャラ表示部分に重ねる想定。
         [SerializeField] private Button _currentCharacterButton;
 
         // 現在選択中のキャラ名を表示するText。
         [SerializeField] private TextMeshProUGUI _characterNameText;
 
         [Header("Scene")]
-        // Additiveで読み込むキャラ選択Scene名
+        // Additiveで読み込むキャラ選択Scene名。
         [SerializeField] private string _characterSelectSceneName = "LobbyCharacterSelectScene";
 
         [Header("Store")]
         [SerializeField] private CharacterSelectionStore _characterSelectionStore;
+
+        [Header("Default Selection")]
+        [SerializeField] private Selectable _returnSelectable;
 
         private IDisposable _selectedCharacterChangedSubscription;
 
@@ -51,13 +55,17 @@ namespace Uraty.Application.Lobby
 
         private void OnEnable()
         {
-            _currentCharacterButton.onClick.AddListener(OpenCharacterSelectScene);
+            if (_currentCharacterButton != null)
+            {
+                _currentCharacterButton.onClick.AddListener(OpenCharacterSelectScene);
+            }
+
             SceneManager.sceneUnloaded += HandleSceneUnloaded;
 
             if (_characterSelectionStore != null)
             {
                 _selectedCharacterChangedSubscription = _characterSelectionStore
-                    .SelectedCharacterChangedStream
+                    .SelectedCharacterPrefabChangedStream
                     .Subscribe(RefreshCharacter);
             }
         }
@@ -70,12 +78,16 @@ namespace Uraty.Application.Lobby
                 return;
             }
 
-            RefreshCharacter(_characterSelectionStore.SelectedCharacter);
+            RefreshCharacter(_characterSelectionStore.SelectedCharacterPrefab);
         }
 
         private void OnDisable()
         {
-            _currentCharacterButton.onClick.RemoveListener(OpenCharacterSelectScene);
+            if (_currentCharacterButton != null)
+            {
+                _currentCharacterButton.onClick.RemoveListener(OpenCharacterSelectScene);
+            }
+
             SceneManager.sceneUnloaded -= HandleSceneUnloaded;
 
             _selectedCharacterChangedSubscription?.Dispose();
@@ -111,6 +123,8 @@ namespace Uraty.Application.Lobby
         {
             _isLoading = true;
 
+            ClearUiSelection();
+
             // キャラ選択画面を開いている間は、
             // ロビー中央の現在選択中キャラとメインUIを非表示にする。
             SetPreviewRootVisible(false);
@@ -127,16 +141,11 @@ namespace Uraty.Application.Lobby
         /// <summary>
         /// 選択中キャラが変わったとき、ロビー中央のキャラ表示を差し替える。
         /// </summary>
-        private void RefreshCharacter(CharacterData character)
+        private void RefreshCharacter(GameObject characterPrefab)
         {
-            // 古い表示用Prefabがあれば削除する。
-            if (_currentPreviewObject != null)
-            {
-                Destroy(_currentPreviewObject);
-                _currentPreviewObject = null;
-            }
+            DestroyCurrentPreview();
 
-            if (character == null)
+            if (characterPrefab == null)
             {
                 if (_characterNameText != null)
                 {
@@ -146,26 +155,36 @@ namespace Uraty.Application.Lobby
                 return;
             }
 
-            // キャラ名を表示する。
             if (_characterNameText != null)
             {
-                _characterNameText.text = character.DisplayName;
+                _characterNameText.text = characterPrefab.name;
             }
 
-            // 表示用Prefabが設定されていない場合は警告を出す。
-            if (character.PreviewPrefab == null)
+            if (_previewRoot == null)
             {
-                Debug.LogWarning($"{character.DisplayName} に PreviewPrefab が設定されていません。");
+                Debug.LogError("PreviewRoot が設定されていません。");
                 return;
             }
 
-            // 選択されたキャラの表示用Prefabをロビー中央に生成する。
             _currentPreviewObject = Instantiate(
-                character.PreviewPrefab,
-                _previewRoot.position,
-                _previewRoot.rotation,
+                characterPrefab,
                 _previewRoot
             );
+
+            _currentPreviewObject.transform.localPosition = Vector3.zero;
+            _currentPreviewObject.transform.localRotation = Quaternion.identity;
+            _currentPreviewObject.transform.localScale = Vector3.one;
+        }
+
+        private void DestroyCurrentPreview()
+        {
+            if (_currentPreviewObject == null)
+            {
+                return;
+            }
+
+            Destroy(_currentPreviewObject);
+            _currentPreviewObject = null;
         }
 
         /// <summary>
@@ -183,6 +202,8 @@ namespace Uraty.Application.Lobby
             // ロビー中央の現在選択中キャラとメインUIを再表示する。
             SetPreviewRootVisible(true);
             SetMainPanelVisible(true);
+
+            StartCoroutine(SelectReturnUiNextFrame());
         }
 
         /// <summary>
@@ -209,6 +230,44 @@ namespace Uraty.Application.Lobby
             }
 
             _mainPanel.SetActive(visible);
+        }
+
+        private IEnumerator SelectReturnUiNextFrame()
+        {
+            yield return null;
+
+            SelectUi(_returnSelectable);
+        }
+
+        private void SelectUi(Selectable selectable)
+        {
+            if (selectable == null)
+            {
+                return;
+            }
+
+            if (EventSystem.current == null)
+            {
+                return;
+            }
+
+            if (!selectable.gameObject.activeInHierarchy)
+            {
+                return;
+            }
+
+            EventSystem.current.SetSelectedGameObject(null);
+            EventSystem.current.SetSelectedGameObject(selectable.gameObject);
+        }
+
+        private void ClearUiSelection()
+        {
+            if (EventSystem.current == null)
+            {
+                return;
+            }
+
+            EventSystem.current.SetSelectedGameObject(null);
         }
     }
 }

--- a/Assets/_Application/Lobby/Scripts/LobbyModeSelectController.cs
+++ b/Assets/_Application/Lobby/Scripts/LobbyModeSelectController.cs
@@ -1,6 +1,10 @@
+using System.Collections.Generic;
+
 using TMPro;
 
 using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 using Uraty.Feature.Akane_GameMode;
@@ -45,6 +49,14 @@ namespace Uraty.Application.Lobby
         // 表示するモードデータ一覧。
         [SerializeField] private GameModeData[] _modes;
 
+        [Header("Default Selection")]
+        [SerializeField] private Selectable _firstMainSelectable;
+
+        [Header("Input")]
+        [SerializeField] private InputActionReference _cancelActionReference;
+
+        private readonly List<ModeButtonView> _modeButtonViews = new();
+
         /// <summary>
         /// 現在選択中のモード。
         /// PlayButtonを押したときに、この値を使ってシーン遷移する。
@@ -75,6 +87,27 @@ namespace Uraty.Application.Lobby
             CloseModePanel();
         }
 
+        private void OnEnable()
+        {
+            if (_cancelActionReference != null)
+            {
+                _cancelActionReference.action.performed += HandleCancelPerformed;
+
+                if (!_cancelActionReference.action.enabled)
+                {
+                    _cancelActionReference.action.Enable();
+                }
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_cancelActionReference != null)
+            {
+                _cancelActionReference.action.performed -= HandleCancelPerformed;
+            }
+        }
+
         /// <summary>
         /// _modes配列の内容に応じて、モード選択ボタンを生成する。
         /// </summary>
@@ -99,6 +132,7 @@ namespace Uraty.Application.Lobby
 
                 // ボタンにモード情報とクリック時処理を渡す。
                 buttonView.Initialize(mode, OnModeButtonClicked);
+                _modeButtonViews.Add(buttonView);
             }
         }
 
@@ -137,6 +171,8 @@ namespace Uraty.Application.Lobby
 
             // UIの手前に表示する。
             _modePanel.transform.SetAsLastSibling();
+
+            SelectUi(GetFirstModeSelectable());
         }
 
         /// <summary>
@@ -148,6 +184,8 @@ namespace Uraty.Application.Lobby
 
             _mainPanel.SetActive(true);
             _modelPanel.SetActive(true);
+
+            SelectUi(_firstMainSelectable);
         }
 
         /// <summary>
@@ -167,6 +205,42 @@ namespace Uraty.Application.Lobby
             }
 
             _selectedModeText.text = SelectedMode.DisplayName;
+        }
+
+        private Selectable GetFirstModeSelectable()
+        {
+            if (_modeButtonViews.Count <= 0)
+            {
+                return _closeButton;
+            }
+
+            return _modeButtonViews[0].Selectable;
+        }
+
+        private void SelectUi(Selectable selectable)
+        {
+            if (selectable == null)
+            {
+                return;
+            }
+
+            if (EventSystem.current == null)
+            {
+                return;
+            }
+
+            EventSystem.current.SetSelectedGameObject(null);
+            EventSystem.current.SetSelectedGameObject(selectable.gameObject);
+        }
+
+        private void HandleCancelPerformed(InputAction.CallbackContext context)
+        {
+            if (_modePanel == null || !_modePanel.activeSelf)
+            {
+                return;
+            }
+
+            CloseModePanel();
         }
     }
 }

--- a/Assets/_Application/Lobby/Scripts/LobbyPlayController.cs
+++ b/Assets/_Application/Lobby/Scripts/LobbyPlayController.cs
@@ -14,11 +14,14 @@ namespace Uraty.Application.Lobby
     public sealed class LobbyPlayController : MonoBehaviour
     {
         // MainPanelにあるプレイ開始ボタン。
+        [Header("Button")]
         [SerializeField] private Button _playButton;
 
         // 現在選択中のモードを取得するためのController。
+        [Header("Controllers")]
         [SerializeField] private LobbyModeSelectController _modeSelectController;
 
+        [Header("Store")]
         [SerializeField] private GameStartDataStore _gameStartDataStore;
 
         private void OnEnable()

--- a/Assets/_Application/Lobby/Scripts/LobbySettingsController.cs
+++ b/Assets/_Application/Lobby/Scripts/LobbySettingsController.cs
@@ -1,6 +1,8 @@
 using TMPro;
 
 using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 using Uraty.Shared.Setting;
@@ -68,6 +70,13 @@ namespace Uraty.Application.Lobby
         // BGM音量の現在値表示。
         [SerializeField] private TextMeshProUGUI _bgmVolumeValueText;
 
+        [Header("Default Selection")]
+        [SerializeField] private Selectable _firstMainSelectable;
+        [SerializeField] private Selectable _firstSettingSelectable;
+
+        [Header("Input")]
+        [SerializeField] private InputActionReference _cancelActionReference;
+
         /// <summary>
         /// 現在のSlider値を設定データとして取得する。
         /// LobbyからBattleへ設定値を渡すときにも使用できる。
@@ -100,6 +109,16 @@ namespace Uraty.Application.Lobby
             _stickDeadZoneSlider.onValueChanged.AddListener(HandleStickDeadZoneChanged);
             _seVolumeSlider.onValueChanged.AddListener(HandleSeVolumeChanged);
             _bgmVolumeSlider.onValueChanged.AddListener(HandleBgmVolumeChanged);
+
+            if (_cancelActionReference != null)
+            {
+                _cancelActionReference.action.performed += HandleCancelPerformed;
+
+                if (!_cancelActionReference.action.enabled)
+                {
+                    _cancelActionReference.action.Enable();
+                }
+            }
         }
 
         private void Start()
@@ -124,6 +143,11 @@ namespace Uraty.Application.Lobby
             _stickDeadZoneSlider.onValueChanged.RemoveListener(HandleStickDeadZoneChanged);
             _seVolumeSlider.onValueChanged.RemoveListener(HandleSeVolumeChanged);
             _bgmVolumeSlider.onValueChanged.RemoveListener(HandleBgmVolumeChanged);
+
+            if (_cancelActionReference != null)
+            {
+                _cancelActionReference.action.performed -= HandleCancelPerformed;
+            }
         }
 
         /// <summary>
@@ -150,6 +174,8 @@ namespace Uraty.Application.Lobby
             _mainPanel.SetActive(false);
             _modelPanel.SetActive(false);
             _settingPanel.SetActive(true);
+
+            SelectUi(_firstSettingSelectable);
         }
 
         /// <summary>
@@ -160,6 +186,24 @@ namespace Uraty.Application.Lobby
             _settingPanel.SetActive(false);
             _mainPanel.SetActive(true);
             _modelPanel.SetActive(true);
+
+            SelectUi(_firstMainSelectable);
+        }
+
+        private void SelectUi(Selectable selectable)
+        {
+            if (selectable == null)
+            {
+                return;
+            }
+
+            if (EventSystem.current == null)
+            {
+                return;
+            }
+
+            EventSystem.current.SetSelectedGameObject(null);
+            EventSystem.current.SetSelectedGameObject(selectable.gameObject);
         }
 
         /// <summary>
@@ -194,6 +238,57 @@ namespace Uraty.Application.Lobby
         private void SaveSettings()
         {
             GameSettingsStore.Save(CurrentSettings);
+        }
+
+        private void HandleCancelPerformed(InputAction.CallbackContext context)
+        {
+            if (_settingPanel == null || !_settingPanel.activeSelf)
+            {
+                return;
+            }
+
+            ConfirmableSlider selectedSlider = GetSelectedConfirmableSlider();
+
+            if (selectedSlider != null && selectedSlider.IsEditing)
+            {
+                return;
+            }
+
+            CloseSettingPanel();
+        }
+
+        private ConfirmableSlider GetSelectedConfirmableSlider()
+        {
+            if (EventSystem.current == null)
+            {
+                return null;
+            }
+
+            GameObject selectedGameObject = EventSystem.current.currentSelectedGameObject;
+
+            if (selectedGameObject == null)
+            {
+                return null;
+            }
+
+            return selectedGameObject.GetComponentInParent<ConfirmableSlider>();
+        }
+
+        private bool IsSliderSelected()
+        {
+            if (EventSystem.current == null)
+            {
+                return false;
+            }
+
+            GameObject selectedGameObject = EventSystem.current.currentSelectedGameObject;
+
+            if (selectedGameObject == null)
+            {
+                return false;
+            }
+
+            return selectedGameObject.GetComponentInParent<Slider>() != null;
         }
 
         /// <summary>

--- a/Assets/_Application/Lobby/Scripts/ModeButtonView.cs
+++ b/Assets/_Application/Lobby/Scripts/ModeButtonView.cs
@@ -34,6 +34,8 @@ namespace Uraty.Application.Lobby
         // 親のLobbyModeSelectControllerから渡される。
         private Action<GameModeData> _onClicked;
 
+        public Selectable Selectable => _button;
+
         /// <summary>
         /// モードボタンの初期化。
         /// 表示内容を更新し、クリック時の通知先を登録する。

--- a/Assets/_Features/Character/Scripts/CharacterAttack.cs
+++ b/Assets/_Features/Character/Scripts/CharacterAttack.cs
@@ -25,6 +25,42 @@ namespace Uraty.Features.Character
         [SerializeField, Min(0f)]
         private float _superChargePercent = 10f;
 
+        public CharacterSkillPreviewInfo PreviewInfo => CreatePreviewInfo();
+
+        private CharacterSkillPreviewInfo CreatePreviewInfo()
+        {
+            if (_attackSettings == null || _attackSettings.Length == 0)
+            {
+                return default;
+            }
+
+            int bulletCount = 0;
+            float totalDamage = 0f;
+            float maxRange = 0f;
+            float maxSpeed = 0f;
+
+            for (int i = 0; i < _attackSettings.Length; i++)
+            {
+                BulletSpawnSetting setting = _attackSettings[i];
+
+                if (setting == null || setting.BulletPrefab == null)
+                {
+                    continue;
+                }
+
+                bulletCount++;
+                totalDamage += setting.Damage;
+                maxRange = Mathf.Max(maxRange, setting.Range);
+                maxSpeed = Mathf.Max(maxSpeed, setting.Speed);
+            }
+
+            return new CharacterSkillPreviewInfo(
+                bulletCount,
+                totalDamage,
+                maxRange,
+                maxSpeed);
+        }
+
         private void Awake()
         {
             if (_status == null)

--- a/Assets/_Features/Character/Scripts/CharacterSkillPreviewInfo.cs
+++ b/Assets/_Features/Character/Scripts/CharacterSkillPreviewInfo.cs
@@ -1,0 +1,36 @@
+namespace Uraty.Features.Character
+{
+    public readonly struct CharacterSkillPreviewInfo
+    {
+        public CharacterSkillPreviewInfo(
+            int bulletCount,
+            float totalDamage,
+            float maxRange,
+            float maxSpeed)
+        {
+            BulletCount = bulletCount;
+            TotalDamage = totalDamage;
+            MaxRange = maxRange;
+            MaxSpeed = maxSpeed;
+        }
+
+        public int BulletCount
+        {
+            get;
+        }
+        public float TotalDamage
+        {
+            get;
+        }
+        public float MaxRange
+        {
+            get;
+        }
+        public float MaxSpeed
+        {
+            get;
+        }
+
+        public bool IsValid => BulletCount > 0;
+    }
+}

--- a/Assets/_Features/Character/Scripts/CharacterSkillPreviewInfo.cs.meta
+++ b/Assets/_Features/Character/Scripts/CharacterSkillPreviewInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 26c62b45b26b19a44b028aa5b3275a4f

--- a/Assets/_Features/Character/Scripts/CharacterSuper.cs
+++ b/Assets/_Features/Character/Scripts/CharacterSuper.cs
@@ -25,6 +25,42 @@ namespace Uraty.Features.Character
         [SerializeField, Min(0f)]
         private float _superChargePercent = 0f;
 
+        public CharacterSkillPreviewInfo PreviewInfo => CreatePreviewInfo();
+
+        private CharacterSkillPreviewInfo CreatePreviewInfo()
+        {
+            if (_superSettings == null || _superSettings.Length == 0)
+            {
+                return default;
+            }
+
+            int bulletCount = 0;
+            float totalDamage = 0f;
+            float maxRange = 0f;
+            float maxSpeed = 0f;
+
+            for (int i = 0; i < _superSettings.Length; i++)
+            {
+                BulletSpawnSetting setting = _superSettings[i];
+
+                if (setting == null || setting.BulletPrefab == null)
+                {
+                    continue;
+                }
+
+                bulletCount++;
+                totalDamage += setting.Damage;
+                maxRange = Mathf.Max(maxRange, setting.Range);
+                maxSpeed = Mathf.Max(maxSpeed, setting.Speed);
+            }
+
+            return new CharacterSkillPreviewInfo(
+                bulletCount,
+                totalDamage,
+                maxRange,
+                maxSpeed);
+        }
+
         private void Awake()
         {
             if (_status == null)

--- a/Assets/_Sandboxes/Akane/Character/Data/Assassin.asset
+++ b/Assets/_Sandboxes/Akane/Character/Data/Assassin.asset
@@ -15,3 +15,4 @@ MonoBehaviour:
   _characterId: 
   _displayName: Assassin
   _previewPrefab: {fileID: 7931562737157900142, guid: e4f55ec51b5d5d346a0a6a7fedc573aa, type: 3}
+  _description: "\u30A2\u30B5\u30B7\u30F3"

--- a/Assets/_Sandboxes/Akane/Character/Data/Attacker.asset
+++ b/Assets/_Sandboxes/Akane/Character/Data/Attacker.asset
@@ -15,3 +15,4 @@ MonoBehaviour:
   _characterId: 
   _displayName: Attacker
   _previewPrefab: {fileID: 414510161762077789, guid: e3ab0d20fafe40b4e956a3adf576b039, type: 3}
+  _description: "\u30A2\u30BF\u30C3\u30AB\u30FC"

--- a/Assets/_Sandboxes/Akane/Character/Data/Fighter.asset
+++ b/Assets/_Sandboxes/Akane/Character/Data/Fighter.asset
@@ -15,3 +15,4 @@ MonoBehaviour:
   _characterId: 
   _displayName: Fighter
   _previewPrefab: {fileID: 9095663280809155271, guid: 76225e6227f412541bdd9faa383d1b72, type: 3}
+  _description: "\u30D5\u30A1\u30A4\u30BF\u30FC"

--- a/Assets/_Sandboxes/Akane/Character/Data/Sniper.asset
+++ b/Assets/_Sandboxes/Akane/Character/Data/Sniper.asset
@@ -15,3 +15,4 @@ MonoBehaviour:
   _characterId: 
   _displayName: Sniper
   _previewPrefab: {fileID: 64248493349735629, guid: bc73278e7d937af409cf4ea00c555844, type: 3}
+  _description: "\u30B9\u30CA\u30A4\u30D1\u30FC"

--- a/Assets/_Sandboxes/Akane/Character/Scripts/CharacterData.cs
+++ b/Assets/_Sandboxes/Akane/Character/Scripts/CharacterData.cs
@@ -12,8 +12,12 @@ namespace Uraty.Feature.Akane_TestCharacter
         [SerializeField] private string _displayName;
         [SerializeField] private GameObject _previewPrefab;
 
+        [SerializeField, TextArea]
+        private string _description;
+
         public string CharacterId => _characterId;
         public string DisplayName => _displayName;
         public GameObject PreviewPrefab => _previewPrefab;
+        public string Description => _description;
     }
 }

--- a/Assets/_Sandboxes/Akane/Character/Scripts/CharacterSelectionStore.cs
+++ b/Assets/_Sandboxes/Akane/Character/Scripts/CharacterSelectionStore.cs
@@ -2,66 +2,43 @@ using R3;
 
 using UnityEngine;
 
-using Uraty.Feature.Akane_TestCharacter;
-
-namespace Uraty.Application.Lobby
+namespace Uraty.Feature.Akane_TestCharacter
 {
-    /// <summary>
-    /// ロビー内で選択中のキャラを保持するStore。
-    /// ScriptableObjectアセットとしてシーン間で共有する。
-    /// </summary>
     [CreateAssetMenu(
         fileName = "CharacterSelectionStore",
-        menuName = "Uraty/Lobby/Character Selection Store"
-    )]
+        menuName = "Uraty/Character/Character Selection Store")]
     public sealed class CharacterSelectionStore : ScriptableObject
     {
-        [SerializeField] private CharacterData _defaultCharacter;
+        [Header("Default")]
+        [SerializeField] private GameObject _defaultCharacterPrefab;
 
-        private readonly Subject<CharacterData> _selectedCharacterChangedSubject = new();
+        [Header("Current")]
+        [SerializeField] private GameObject _selectedCharacterPrefab;
 
-        private CharacterData _selectedCharacter;
+        private readonly Subject<GameObject> _selectedCharacterPrefabChangedSubject = new();
 
-        public CharacterData SelectedCharacter
+        public GameObject SelectedCharacterPrefab =>
+            _selectedCharacterPrefab != null
+                ? _selectedCharacterPrefab
+                : _defaultCharacterPrefab;
+
+        public Observable<GameObject> SelectedCharacterPrefabChangedStream =>
+            _selectedCharacterPrefabChangedSubject;
+
+        public void SetSelectedCharacterPrefab(GameObject characterPrefab)
         {
-            get
-            {
-                if (_selectedCharacter != null)
-                {
-                    return _selectedCharacter;
-                }
-
-                return _defaultCharacter;
-            }
-        }
-
-        public Observable<CharacterData> SelectedCharacterChangedStream =>
-            _selectedCharacterChangedSubject;
-
-        public void SetSelectedCharacter(CharacterData character)
-        {
-            if (character == null)
+            if (_selectedCharacterPrefab == characterPrefab)
             {
                 return;
             }
 
-            _selectedCharacter = character;
-            PublishSelectedCharacterChanged(character);
+            _selectedCharacterPrefab = characterPrefab;
+            _selectedCharacterPrefabChangedSubject.OnNext(SelectedCharacterPrefab);
         }
 
-        public void Clear()
+        private void OnDestroy()
         {
-            _selectedCharacter = null;
-
-            if (_defaultCharacter != null)
-            {
-                PublishSelectedCharacterChanged(_defaultCharacter);
-            }
-        }
-
-        private void PublishSelectedCharacterChanged(CharacterData character)
-        {
-            _selectedCharacterChangedSubject.OnNext(character);
+            _selectedCharacterPrefabChangedSubject.Dispose();
         }
     }
 }

--- a/Assets/_Sandboxes/Akane/Respawn.meta
+++ b/Assets/_Sandboxes/Akane/Respawn.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: bdbcfa02e6bd9eb4d8480fa4ed5d85f1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/_Sandboxes/Akane/Respawn/Scripts.meta
+++ b/Assets/_Sandboxes/Akane/Respawn/Scripts.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3fde2da06d7874940a1c6940d9038357
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/_Systems/Input/Actions/GameInputActions.inputactions
+++ b/Assets/_Systems/Input/Actions/GameInputActions.inputactions
@@ -208,6 +208,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "Navigate",
+                    "type": "Value",
+                    "id": "d0622520-b226-4d00-8485-3f9799394a81",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
                 }
             ],
             "bindings": [
@@ -258,7 +267,7 @@
                 {
                     "name": "",
                     "id": "1802afe6-8c96-436f-b411-e4a1fcb96835",
-                    "path": "<Gamepad>/rightStick",
+                    "path": "<Gamepad>/leftStick",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -274,6 +283,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "Point",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "bb8cdc4d-78aa-458b-9435-482056daac52",
+                    "path": "<Gamepad>/dpad",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/_Systems/Input/Scripts/GameInputActions.cs
+++ b/Assets/_Systems/Input/Scripts/GameInputActions.cs
@@ -296,6 +296,15 @@ namespace Uraty.Systems.Input
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Navigate"",
+                    ""type"": ""Value"",
+                    ""id"": ""d0622520-b226-4d00-8485-3f9799394a81"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": true
                 }
             ],
             ""bindings"": [
@@ -346,7 +355,7 @@ namespace Uraty.Systems.Input
                 {
                     ""name"": """",
                     ""id"": ""1802afe6-8c96-436f-b411-e4a1fcb96835"",
-                    ""path"": ""<Gamepad>/rightStick"",
+                    ""path"": ""<Gamepad>/leftStick"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
@@ -362,6 +371,17 @@ namespace Uraty.Systems.Input
                     ""processors"": """",
                     ""groups"": """",
                     ""action"": ""Point"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""bb8cdc4d-78aa-458b-9435-482056daac52"",
+                    ""path"": ""<Gamepad>/dpad"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Navigate"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 }
@@ -381,6 +401,7 @@ namespace Uraty.Systems.Input
             m_UI_Cancel = m_UI.FindAction("Cancel", throwIfNotFound: true);
             m_UI_Submit = m_UI.FindAction("Submit", throwIfNotFound: true);
             m_UI_Point = m_UI.FindAction("Point", throwIfNotFound: true);
+            m_UI_Navigate = m_UI.FindAction("Navigate", throwIfNotFound: true);
         }
 
         ~@GameInputActions()
@@ -594,6 +615,7 @@ namespace Uraty.Systems.Input
         private readonly InputAction m_UI_Cancel;
         private readonly InputAction m_UI_Submit;
         private readonly InputAction m_UI_Point;
+        private readonly InputAction m_UI_Navigate;
         /// <summary>
         /// Provides access to input actions defined in input action map "UI".
         /// </summary>
@@ -617,6 +639,10 @@ namespace Uraty.Systems.Input
             /// Provides access to the underlying input action "UI/Point".
             /// </summary>
             public InputAction @Point => m_Wrapper.m_UI_Point;
+            /// <summary>
+            /// Provides access to the underlying input action "UI/Navigate".
+            /// </summary>
+            public InputAction @Navigate => m_Wrapper.m_UI_Navigate;
             /// <summary>
             /// Provides access to the underlying input action map instance.
             /// </summary>
@@ -652,6 +678,9 @@ namespace Uraty.Systems.Input
                 @Point.started += instance.OnPoint;
                 @Point.performed += instance.OnPoint;
                 @Point.canceled += instance.OnPoint;
+                @Navigate.started += instance.OnNavigate;
+                @Navigate.performed += instance.OnNavigate;
+                @Navigate.canceled += instance.OnNavigate;
             }
 
             /// <summary>
@@ -672,6 +701,9 @@ namespace Uraty.Systems.Input
                 @Point.started -= instance.OnPoint;
                 @Point.performed -= instance.OnPoint;
                 @Point.canceled -= instance.OnPoint;
+                @Navigate.started -= instance.OnNavigate;
+                @Navigate.performed -= instance.OnNavigate;
+                @Navigate.canceled -= instance.OnNavigate;
             }
 
             /// <summary>
@@ -769,6 +801,13 @@ namespace Uraty.Systems.Input
             /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
             /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnPoint(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "Navigate" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnNavigate(InputAction.CallbackContext context);
         }
     }
 }


### PR DESCRIPTION
Issue:
- Refs #142

## Reason
- テストプレイ時に「キャラのステータスを見えるようにしてほしい」との意見があったため。

## Notes
- リベース前にプッシュしてしまってため、コンフリクト解消（フォントの階層変更のみ・mainを優先）後にforce pushしました。
- 担当外の下記の変更を加えました（報告・了承済み）
・_Features/Character/Scriptsにキャラ情報表示用データ
・CharacterAttack/CharacterSuperに表示用データ受け渡し用のゲッター